### PR TITLE
Better reflect repo naming for git cloners and update theme path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 version: '2.3'
 
 x-lagoon-project:
-  &lagoon-project govcms-saas
+  &lagoon-project govcms7-scaffold
 
 x-lagoon-local-dev-url:
-  &lagoon-local-dev-url http://govcms-saas.docker.amazee.io
+  &lagoon-local-dev-url http://govcms7-scaffold.docker.amazee.io
 
 x-volumes:
   &default-volumes
     volumes:
-      - ./themes:/app/profiles/govcms/themes/custom:${VOLUME_FLAGS:-delegated}
+      - ./themes:/app/sites/default/themes/custom:${VOLUME_FLAGS:-delegated}
       - ./files:/app/sites/default/files:delegated
       - ./tests/behat/features:/app/tests/behat/features:${VOLUME_FLAGS:-delegated}
       - ./tests/phpunit/tests:/app/tests/phpunit/tests:${VOLUME_FLAGS:-delegated}
@@ -17,7 +17,7 @@ x-volumes:
 x-environment:
   &default-environment
     LAGOON_PROJECT: *lagoon-project
-    LAGOON_ROUTE: &default-url ${LOCALDEV_URL:-http://govcms.docker.amazee.io}
+    LAGOON_ROUTE: &default-url ${LOCALDEV_URL:-http://govcms7-scaffold.docker.amazee.io}
 
 services:
 


### PR DESCRIPTION
calling the project the same as the project name may reduce confusion.

Updated theme path to `/app/sites/default/themes/custom` instead of the cumbersome and legacy `/app/profiles/govcms/themes/custom` - This may need testing with AWX (although i can't see anything explicitly requiring the theme to be under profiles/govcms

The theme path matches the logic for the govcms8 version now