### PR TITLE
add in sql import/dump commands

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -50,6 +50,19 @@ commands:
     usage: Login to a website.
     cmd: docker-compose exec -T test drush uli "$@"
 
+  mysql-import:
+    usage: Pipe in a sql file.  `ahoy mysql-import local.sql`
+    cmd: |
+      if [ -e "$@" ] ; then
+        docker-compose exec test bash -c 'drush sql-drop' &&
+        docker-compose exec -T test bash -c 'drush sql-cli' < "$@"
+      else echo "Provided sql file" "$@" "does not exist"
+      fi
+
+  mysql-dump:
+    usage: Dump data out into a file. `ahoy mysql-dump local.sql`
+    cmd: docker-compose exec test bash -c 'drush sql-dump --ordered-dump' > "$@"
+
   lint:
     usage: Lint code
     cmd: docker-compose exec -T test lint-theme


### PR DESCRIPTION
This PR allows a local dev user to be able to import and export a local database dump.

I have added a couple of failsafes:
* it will test that the sql file exists before it starts
* it will prompt before dropping the current database

The dump command has been made as an `--ordered-dump` in case the db gets added into a git repo.