### PR TITLE
re-add mysql commands and document their usage

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -54,6 +54,19 @@ commands:
     usage: Login to a website.
     cmd: docker-compose exec -T test drush uli "$@"
 
+  mysql-import:
+    usage: Pipe in a sql file.  `ahoy mysql-import local.sql`
+    cmd: |
+      if [ -e "$@" ] ; then
+        docker-compose exec test bash -c 'drush sql-drop' &&
+        docker-compose exec -T test bash -c 'drush sql-cli' < "$@"
+      else echo "Provided sql file" "$@" "does not exist"
+      fi
+      
+  mysql-dump:
+    usage: Dump data out into a file. `ahoy mysql-dump local.sql`
+    cmd: docker-compose exec test bash -c 'drush sql-dump --ordered-dump' > "$@"
+
   lint:
     usage: Lint code
     cmd: docker-compose exec -T test lint-theme

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ The GovCMS projects have been designed to be able to import a nightly copy of th
 
 1: Using the GitLab container registry nightly backup
 As per the instructions in https://projects.govcms.gov.au/{org}/{project}/container_registry
-a. add a GitLab Personal Access Token with `read_registry` scope (profile/personal_access_tokens)
-b. `docker login gitlab-registry-production.govcms.amazee.io` (and use the PAT created above as the password)
-c. `ahoy up` (or the docker-compose equivalent)
-d. to refresh the db with a newer version, run `ahoy up` again
+* add a GitLab Personal Access Token with `read_registry` scope (profile/personal_access_tokens)
+* `docker login gitlab-registry-production.govcms.amazee.io` (and use the PAT created above as the password)
+* `ahoy up` (or the docker-compose equivalent)
+* to refresh the db with a newer version, run `ahoy up` again
 
 2: Use the backups accessible via the UI
-a. Head to https://ui-lagoon.govcms.amazee.io/backups?name={project}-master
-b. Click "Prepare download" for the most recent mysql backup you want - note that you will have to refresh the page to see when it is complete
-c. Download that backup into your project folder
-d. `ahoy mysql-import` to import the dump you just saved
+* head to https://ui-lagoon.govcms.amazee.io/backups?name={project}-master
+* click "Prepare download" for the most recent mysql backup you want - note that you will have to refresh the page to see when it is complete
+* download that backup into your project folder
+* `ahoy mysql-import` to import the dump you just saved
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@
 
 Additional commands are listed in `.ahoy.yml`, or available from the command line `ahoy -v`
 
+## Databases
+
+The GovCMS projects have been designed to be able to import a nightly copy of the latest `master` branch database in two ways:
+
+1: Using the GitLab container registry nightly backup
+As per the instructions in https://projects.govcms.gov.au/{org}/{project}/container_registry
+a. add a GitLab Personal Access Token with `read_registry` scope (profile/personal_access_tokens)
+b. `docker login gitlab-registry-production.govcms.amazee.io` (and use the PAT created above as the password)
+c. `ahoy up` (or the docker-compose equivalent)
+d. to refresh the db with a newer version, run `ahoy up` again
+
+2: Use the backups accessible via the UI
+a. Head to https://ui-lagoon.govcms.amazee.io/backups?name={project}-master
+b. Click "Prepare download" for the most recent mysql backup you want - note that you will have to refresh the page to see when it is complete
+c. Download that backup into your project folder
+d. `ahoy mysql-import` to import the dump you just saved
+
 ## Development
 
 * You should create your theme(s) in folders under `/themes`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Additional commands are listed in `.ahoy.yml`, or available from the command lin
 The GovCMS projects have been designed to be able to import a nightly copy of the latest `master` branch database in two ways:
 
 1: Using the GitLab container registry nightly backup
-As per the instructions in https://projects.govcms.gov.au/{org}/{project}/container_registry
+* these instructions are for https://projects.govcms.gov.au/{org}/{project}/container_registry
 * add a GitLab Personal Access Token with `read_registry` scope (profile/personal_access_tokens)
 * `docker login gitlab-registry-production.govcms.amazee.io` (and use the PAT created above as the password)
 * `ahoy up` (or the docker-compose equivalent)
@@ -73,7 +73,7 @@ As per the instructions in https://projects.govcms.gov.au/{org}/{project}/contai
 
 ## Image inheritance
 
-This project is designed to provision a Drupal 8 project onto GovCMS SaaS, using the GovCMS8 distribution, and has been prepared thus
+This project is designed to provision a Drupal 7 project onto GovCMS SaaS, using the GovCMS distribution, and has been prepared thus
 
 1. The vanilla GovCMS (7.x-3.x) Distribution is available at [Github Source](https://github.com/govcms/govcms) and as [Public DockerHub images](https://hub.docker.com/r/govcms)
 2. Those GovCMS images are then customised for Lagoon and GovCMS, and are available at [Github Source](https://github.com/govcms/govcmslagoon) and as [Public DockerHub images](https://hub.docker.com/r/govcmslagoon)


### PR DESCRIPTION
that were added in https://github.com/govCMS/govcms7-scaffold/pull/4 but have disappeared