### PR TITLE
use none type for Redis on Lagoon

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -11,6 +11,7 @@ environments:
   master:
     types:
       mariadb: mariadb-shared
+      redis: none
     cronjobs:
       - name: drush cron
         schedule: "*/15 * * * *"


### PR DESCRIPTION
Setting lagoon.type to none for Redis will stop Redis pods from deploying on Lagoon.  

Setting it in .lagoon.yml allows it to be more easily overridden on a project-by-project basis, in a way that is still scaffold update compatible.

Redis may be re-enabled in the future, or converted to a service broker, hence not removing it entirely.

Ref: GOVCMSD7-49