### PR TITLE
Feature: improved initialisation commands

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -8,11 +8,15 @@ commands:
 
   init:
     usage: Build the project from scratch with the latest versions of all containers.
-    cmd: ahoy rebuild
+    cmd: |
+      ahoy rebuild
+      echo "If that all went well, you should be ready to run: ahoy install"
 
   rebuild:
     usage: Force all containers to be rebuilt from source (useful if you're getting stuck with old or mixed up containers)
-    cmd: docker-compose build --no-cache && docker-compose up -d --force-recreate
+    cmd: |
+      docker-compose build --no-cache
+      docker-compose up -d --force-recreate
 
   down:
     usage: Delete project (CAUTION).

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -6,6 +6,14 @@ commands:
     usage: Build project.
     cmd: docker-compose up -d "$@";
 
+  init:
+    usage: Build the project from scratch with the latest versions of all containers.
+    cmd: ahoy rebuild
+
+  rebuild:
+    usage: Force all containers to be rebuilt from source (useful if you're getting stuck with old or mixed up containers)
+    cmd: docker-compose build --no-cache && docker-compose up -d --force-recreate
+
   down:
     usage: Delete project (CAUTION).
     cmd: |

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ If the project isn't behaving as expected you can try to force all containers to
         Windows:    docker-compose build --no-cache
                     docker-compose up -d --force-recreate
                     
-and follow the [Lagoon troubleshooting instructions](https://docs.amazee.io/local_docker_development/troubleshooting.html).
+If that doesn't work follow the [Lagoon troubleshooting instructions](https://docs.amazee.io/local_docker_development/troubleshooting.html).

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@
 
 2. Build and start the containers:
 
-        Mac/Linux:  ahoy up
-        Windows:    docker-compose up -d
+        Mac/Linux:  ahoy init
+        Windows:    docker-compose build --no-cache 
+                    docker-compose up -d
 
 3. Install GovCMS:
 
@@ -78,3 +79,13 @@ This project is designed to provision a Drupal 7 project onto GovCMS SaaS, using
 1. The vanilla GovCMS (7.x-3.x) Distribution is available at [Github Source](https://github.com/govcms/govcms) and as [Public DockerHub images](https://hub.docker.com/r/govcms)
 2. Those GovCMS images are then customised for Lagoon and GovCMS, and are available at [Github Source](https://github.com/govcms/govcmslagoon) and as [Public DockerHub images](https://hub.docker.com/r/govcmslagoon)
 3. Those GovCMSlagoon images are then retrieved in this scaffold repository.
+
+## Troubleshooting
+
+If the project isn't behaving as expected you can try to force all containers to rebuild with:
+        
+        Mac/Linux:  ahoy rebuild
+        Windows:    docker-compose build --no-cache
+                    docker-compose up -d --force-recreate
+                    
+and follow the [Lagoon troubleshooting instructions](https://docs.amazee.io/local_docker_development/troubleshooting.html).


### PR DESCRIPTION
Following on from the troubleshooting in #12 I've modified the ahoy files to include a few extra options to stop anyone else running in to similar issues.

My scenario is uncommon because I have multiple versions of govCMS scaffolds for different purposes, but what I didn't understand was that my other projects were 'leaking' their modified containers in to this one.

It's possible that others could find themselves in a similar boat in future.

To mitigate this, I've proposed that the readme uses a different command ```ahoy init``` when you first set up the project that will force it to use the exact containers specified and not cached versions that might already exist on the users machine.

I've also created an additional command ```ahoy rebuild``` that does the same thing but with the idea that if someone has been working on a project for a long time and updates have been made upstream, that they may want to effective force refresh and get the latest version of everything back to a known good state.

Finally, I've added in a link to the Lagoon troubleshooting section (from the old lagoon docs as this section hasn't been moved to the new version yet that I could see) at the bottom of the readme.

Hopefully these small mods should mean all future users can reliably generate the scaffold exactly as intended regardless of what else they may have installed previously.
  
